### PR TITLE
feat: support passing extra git arguments (RDT-1306)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ WORKDIR /app
 COPY requirements.txt release_zips/release_zips.py ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT ["python", "release_zips.py"]
+ENTRYPOINT ["python", "/app/release_zips.py"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ If a Release already exists for the given tag, then the zip file is attached to 
 
 If the tag contains `-` then a new Draft is marked as Pre-release and this is also mentioned in the title. The naming scheme for a new draft is based on ESP-IDF, and is `$RELEASE_PROJECT_NAME [Pre-release|Release] $TAG`. Both these things can be edited before publishing the new release.
 
+## Inputs
+
+| Name                   | Description                                                                 | Required | Default         |
+| ---------------------- | --------------------------------------------------------------------------- | -------- | --------------- |
+| `github_token`         | GitHub token to authenticate release and clone operations                   | Yes      | –               |
+| `release_project_name` | Project name used in release title                                          | No       | repository name |
+| `git_extra_args`       | Extra arguments passed to `git clone` (e.g. `--shallow-since="1 year ago"`) | No       | `""`            |
+
 ## Example Workflow yaml file
 
 ```yml
@@ -30,11 +38,16 @@ jobs:
     steps:
       - name: Create a recursive clone source zip for a Release
         uses: espressif/release-zips-action@v1
-        env:
-            RELEASE_PROJECT_NAME: ESP-IDF
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_project_name: ESP-IDF
+          git_extra_args: --shallow-since="1 year ago"
 ```
 
 - Note the `tags` filter for `push`, this limits the tag patterns for which a zip file should be created.
-- `RELEASE_PROJECT_NAME` is the name that will be used in the Draft Release title, of the form "$RELEASE_PROJECT_NAME [Pre-release|Release] $TAG"
-- `GITHUB_TOKEN` is needed to create the release, and used as a credential when cloning from GitHub (just in case). The token is not stored in the working directory, though.
+- `release_project_name` is the name that will be used in the Draft Release title. The format is: `$RELEASE_PROJECT_NAME [Pre-release|Release] $TAG`
+- `github_token` is used to authenticate the GitHub API (for creating releases) and to clone private submodules if
+  needed. The token is not stored in the resulting working directory.
+- `git_extra_args` is passed to `git clone`, so you can use it to limit the history of the clone. This is useful if you
+  have a large repo and want to limit the size of the zip file. For example, `--shallow-since="1 year ago"` will only
+  include commits from the last year.

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,10 @@ inputs:
   release_project_name:
     description: "Name of the project to appear in the release"
     required: false
-  inputs:
-    git_extra_args:
-      description: 'Extra arguments for git clone (e.g. --shallow-since="1 year ago")'
-      required: false
-      default: ''
+  git_extra_args:
+    description: 'Extra arguments for git clone (e.g. --shallow-since="1 year ago")'
+    required: false
+    default: ''
 
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,12 @@ inputs:
   release_project_name:
     description: "Name of the project to appear in the release"
     required: false
+  inputs:
+    git_extra_args:
+      description: 'Extra arguments for git clone (e.g. --shallow-since="1 year ago")'
+      required: false
+      default: ''
+
 
 runs:
   using: "docker"
@@ -16,3 +22,4 @@ runs:
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     RELEASE_PROJECT_NAME: ${{ inputs.release_project_name }}
+    INPUT_GIT_EXTRA_ARGS: ${{ inputs.git_extra_args }}

--- a/release_zips/release_zips.py
+++ b/release_zips/release_zips.py
@@ -2,23 +2,10 @@
 
 import argparse
 import os
-import shlex
 import subprocess
 
 from github import Github
 from github import GithubException
-
-# Define an allowlist of allowed git arguments
-ALLOWED_GIT_ARGS = ['--shallow-since']
-
-
-def validate_git_args(extra_args):
-    parsed_args = shlex.split(extra_args)
-    for arg in parsed_args:
-        # Check if the argument starts with an allowed prefix
-        if not any(arg.startswith(allowed) for allowed in ALLOWED_GIT_ARGS):
-            raise ValueError(f'Invalid git argument: {arg}')
-    return parsed_args
 
 
 def main():
@@ -52,14 +39,7 @@ def main():
     repo_name = github_repo.split('/')[1]
     directory = f'{repo_name}-{tag}'
 
-    clone_cmd = ['git', 'clone', '--recursive', '--branch', tag]
-    if git_extra_args:
-        try:
-            validated_args = validate_git_args(git_extra_args)
-            clone_cmd.extend(validated_args)
-        except ValueError as e:
-            raise SystemExit(str(e)) from e
-    clone_cmd.extend([git_url, directory])
+    clone_cmd = ['git', 'clone', '--recursive', '--branch', tag, git_extra_args, git_url, directory]
     print(f'Cloning {git_url} (tag: {tag}) into {directory}...')
     print(f'Running: {" ".join(clone_cmd)}')
     subprocess.run(clone_cmd, check=True)

--- a/release_zips/release_zips.py
+++ b/release_zips/release_zips.py
@@ -1,13 +1,28 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
+import shlex
 import subprocess
 
 from github import Github
 from github import GithubException
 
+# Define an allowlist of allowed git arguments
+ALLOWED_GIT_ARGS = ['--shallow-since']
+
+
+def validate_git_args(extra_args):
+    parsed_args = shlex.split(extra_args)
+    for arg in parsed_args:
+        # Check if the argument starts with an allowed prefix
+        if not any(arg.startswith(allowed) for allowed in ALLOWED_GIT_ARGS):
+            raise ValueError(f'Invalid git argument: {arg}')
+    return parsed_args
+
 
 def main():
+    git_extra_args = os.environ.get("INPUT_GIT_EXTRA_ARGS")
     ref = os.environ.get('GITHUB_REF')
     if not ref:
         raise SystemExit('Not an event based on a push. Workflow configuration is wrong?')
@@ -37,8 +52,17 @@ def main():
     repo_name = github_repo.split('/')[1]
     directory = f'{repo_name}-{tag}'
 
+    clone_cmd = ['git', 'clone', '--recursive', '--branch', tag]
+    if git_extra_args:
+        try:
+            validated_args = validate_git_args(git_extra_args)
+            clone_cmd.extend(validated_args)
+        except ValueError as e:
+            raise SystemExit(str(e)) from e
+    clone_cmd.extend([git_url, directory])
     print(f'Cloning {git_url} (tag: {tag}) into {directory}...')
-    subprocess.run(['git', 'clone', '--recursive', '--branch', tag, git_url, directory], check=True)
+    print(f'Running: {" ".join(clone_cmd)}')
+    subprocess.run(clone_cmd, check=True)
 
     zipfile = f'{directory}.zip'
     print(f'Creating zip archive {zipfile}...')


### PR DESCRIPTION
## Description
GitHub has a 2GB file size limit for uploading release assets via the CLI. Currently, the esp-idf project's full Git history results in an archive size of approximately 2.2 GB, which exceeds this limit and causes the GitHub Action to fail.

This PR introduces support for passing custom Git arguments via a --git-extra-args input (e.g., --shallow-since="1 year ago") to limit the cloned history. For example, using --shallow-since="1 year ago" reduced the ZIP size from 2.1 GB to 1.2 GB during the v5.4.1 release.

This change helps keep future releases (e.g., v5.4.2, v5.5) within the upload size limit, avoiding the need for manual intervention.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Fixes https://github.com/espressif/esp-idf/actions/runs/14112915718/job/39535967952
Closes IDFCI-2827

## Testing

To validate this change, I forked the [esp-idf](https://github.com/vsaltxx/esp-idf) repository and configured it to use the updated release-zips-action via the [feat/git-extra-args](https://github.com/vsaltxx/release-zips-action/tree/feat%2Fgit-extra-args) branch.

I then triggered the workflow by pushing a new tag v5.5.90.

- The GitHub Actions workflow completed successfully.
- The archive was created and uploaded to the GitHub release draft.
- The final ZIP archive size was 1.21 GB, well within the 2GB limit.

Testing pipeline: https://github.com/vsaltxx/esp-idf/actions/runs/15135342021/job/42545716796

<details>
<summary>CI and Release Screenshots</summary>

<img src="https://github.com/user-attachments/assets/ee65f3ca-ecc3-46a4-afc9-5271d768819a" width=500px>
<img src="https://github.com/user-attachments/assets/f88b5475-067d-45fb-9070-b4c6c358190c" width=500px>


</details>
**Run with full Git history**: 
```bash
 python3 release_zips.py
 du -h esp-idf-v5.4.1.zip
```
**Output**: 
```
Size of the full-history clone: 2.2 GB
```

**Run with shallow Git history** : 
```bash
 python3 release_zips.py --git-extra-args='--shallow-since="1 year ago"'
 du -h esp-idf-v5.4.1.zip
```
**Output**: 
```
Size of the full-history clone: 1.2 GB
```
---